### PR TITLE
Optimize Docker build and add CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+.github

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,19 @@
+name: Build Docker Image
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,89 @@
-FROM ubuntu:latest 
+FROM debian:stable-slim AS builder
 
-LABEL AUTHOR="ben@lobmueller.com"
-
+ENV DEBIAN_FRONTEND=noninteractive
 ENV LD_LIBRARY_PATH=/usr/local/lib
 
-RUN apt-get update --fix-missing
-RUN apt -y install software-properties-common 
-RUN add-apt-repository universe
-RUN apt-get update --fix-missing
-RUN apt-get -y install wget make pkg-config gcc libgcrypt20-dev nettle-dev unbound libgtk-3-dev build-essential libgtk2.0-dev qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libxml2-dev libxslt-dev --fix-missing
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates wget make pkg-config gcc g++ build-essential \
+    libgcrypt20-dev nettle-dev unbound \
+    libgtk-3-dev libgtk2.0-dev qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools \
+    libxml2-dev libxslt-dev libxmlsec1-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN wget http://www.aleksey.com/xmlsec/download/xmlsec1-1.2.34.tar.gz
-RUN tar -xf xmlsec1-1.2.34.tar.gz
-RUN cd xmlsec1-1.2.34 && ./configure && make && make install
 
-RUN wget https://github.com/libffi/libffi/releases/download/v3.4.2/libffi-3.4.2.tar.gz
-RUN tar -xf libffi-3.4.2.tar.gz
-RUN cd libffi-3.4.2 && ./configure && make && make check && make install
+# libffi
+RUN wget https://github.com/libffi/libffi/releases/download/v3.4.2/libffi-3.4.2.tar.gz \
+ && tar -xf libffi-3.4.2.tar.gz \
+ && cd libffi-3.4.2 \
+ && ./configure \
+ && make \
+ && make check \
+ && make install \
+ && cd .. \
+ && rm -rf libffi-3.4.2*
 
-RUN wget https://ftp.gnu.org/gnu/libtasn1/libtasn1-4.19.0.tar.gz
-RUN tar -xf libtasn1-4.19.0.tar.gz
-RUN cd libtasn1-4.19.0 && ./configure && make && make check && make install
+# libtasn1
+RUN wget https://ftp.gnu.org/gnu/libtasn1/libtasn1-4.19.0.tar.gz \
+ && tar -xf libtasn1-4.19.0.tar.gz \
+ && cd libtasn1-4.19.0 \
+ && ./configure \
+ && make \
+ && make check \
+ && make install \
+ && cd .. \
+ && rm -rf libtasn1-4.19.0*
 
-RUN wget https://github.com/p11-glue/p11-kit/releases/download/0.24.1/p11-kit-0.24.1.tar.xz
-RUN tar -xf p11-kit-0.24.1.tar.xz
-RUN cd p11-kit-0.24.1 && ./configure && make && make check && make install
+# p11-kit
+RUN wget https://github.com/p11-glue/p11-kit/releases/download/0.24.1/p11-kit-0.24.1.tar.xz \
+ && tar -xf p11-kit-0.24.1.tar.xz \
+ && cd p11-kit-0.24.1 \
+ && ./configure \
+ && make \
+ && make check \
+ && make install \
+ && cd .. \
+ && rm -rf p11-kit-0.24.1*
 
-RUN wget https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.16.tar.xz
-RUN tar -xf gnutls-3.6.16.tar.xz
-RUN cd gnutls-3.6.16 && ./configure --with-included-unistring && make && make install
+# gnutls
+RUN wget https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.16.tar.xz \
+ && tar -xf gnutls-3.6.16.tar.xz \
+ && cd gnutls-3.6.16 \
+ && ./configure --with-included-unistring \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf gnutls-3.6.16*
 
-RUN wget https://www.aquamaniac.de/rdm/attachments/download/415/gwenhywfar-5.9.0.tar.gz
-RUN tar -xf gwenhywfar-5.9.0.tar.gz
-RUN cd gwenhywfar-5.9.0 && ./configure && make && make install
+# gwenhywfar
+RUN wget https://www.aquamaniac.de/rdm/attachments/download/415/gwenhywfar-5.9.0.tar.gz \
+ && tar -xf gwenhywfar-5.9.0.tar.gz \
+ && cd gwenhywfar-5.9.0 \
+ && ./configure \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf gwenhywfar-5.9.0*
 
 RUN ldconfig
 
-RUN wget https://www.aquamaniac.de/rdm/attachments/download/467/aqbanking-6.5.3.tar.gz
-RUN tar -xf aqbanking-6.5.3.tar.gz
-RUN cd aqbanking-6.5.3 && ./configure && make && make install
+# aqbanking
+RUN wget https://www.aquamaniac.de/rdm/attachments/download/467/aqbanking-6.5.3.tar.gz \
+ && tar -xf aqbanking-6.5.3.tar.gz \
+ && cd aqbanking-6.5.3 \
+ && ./configure \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf aqbanking-6.5.3*
 
 RUN ldconfig
+
+FROM debian:stable-slim AS runtime
+ENV LD_LIBRARY_PATH=/usr/local/lib
+COPY --from=builder /usr/local /usr/local
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates libgcrypt20 nettle unbound libgtk-3-0 libgtk2.0-0 \
+    qt5-gtk-platformtheme libxml2 libxslt1.1 libxmlsec1 \
+    && rm -rf /var/lib/apt/lists/*
+RUN ldconfig
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # aqbanking-docker
 
-Building a basic aqbanking-docker image. Tested on Debian & aarch64.
+[![Docker Build](https://github.com/lobochrome/aqbanking-docker/actions/workflows/docker-build.yml/badge.svg)](https://github.com/lobochrome/aqbanking-docker/actions/workflows/docker-build.yml)
+
+A Docker image for building and running AqBanking. The image uses a multi-stage
+build on top of `debian:stable-slim` to keep the final size small. The
+`.dockerignore` file keeps unnecessary files like Git metadata out of the build
+context.
+
+## Building locally
+
+```bash
+docker build -t aqbanking .
+```
+
+## Continuous integration
+
+The repository contains a GitHub Actions workflow that builds the Docker image on
+every push to verify that the Dockerfile remains valid.


### PR DESCRIPTION
## Summary
- make Docker image smaller using multi-stage build
- document build and CI in README with badge
- add GitHub Action to ensure Dockerfile builds
- install xmlsec from packages and add `.dockerignore`

## Testing
- `docker --version` *(fails: command not found)*
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683cf4151d108333990cf1080fc5df24